### PR TITLE
Category endpoints (Multiple Features)

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,7 +4,7 @@ from flask_sqlalchemy import SQLAlchemy
 
 # local import
 from instance.config import app_config
-from app.restplus import API
+
 
 # initialize sql-alchemy
 db = SQLAlchemy()
@@ -13,4 +13,10 @@ APP = Flask(__name__, instance_relative_config=True)
 APP.config.from_object(app_config['development'])
 db.init_app(APP)
 
-from app.api import API
+from app.restplus import API
+from app.auth import auth_ns
+from app.categories import categories_ns
+
+API.add_namespace(auth_ns)
+API.add_namespace(categories_ns)
+API.init_app(APP)

--- a/app/auth.py
+++ b/app/auth.py
@@ -49,11 +49,15 @@ def authorization_required(func):
         
         token = None
 
-        if 'access_token' in request.headers:
-            token = request.headers['access_token']
+        if 'Authorization' in request.headers:
+            token = request.headers['Authorization']
 
         if not token:
-            return make_response(jsonify({"message": "Please provide an access token!"}), 401)
+            response_obj = {
+                "message": "Please provide an access token!",
+                "status": "Fail!"
+            }
+            return make_response(jsonify(response_obj), 401)
 
         result = decode_access_token(token)
 
@@ -89,7 +93,7 @@ class RegisterHandler(Resource):
                 response = {"message": "Some error occured. Please retry."}
                 return make_response(jsonify(response), 501)
         else:
-            return make_response(jsonify({'message': 'User already exists. Please Log in instead.'}), 202)
+            return make_response(jsonify({'message': 'User already exists. Please Log in instead.'}), 400)
 
 @auth_ns.route('/login')
 class LoginHandler(Resource):
@@ -134,12 +138,11 @@ class LogoutHandler(Resource):
     This class handles user logout
     """
 
-    @API.expect(auth_header, validate=True)
     def post(self):
         """
         Logout route
         """
-        access_token = request.headers.get('access_token')
+        access_token = request.headers.get('Authorization')
         print(access_token, file=sys.stdout)
         if access_token:
             result = decode_access_token(access_token)
@@ -217,8 +220,3 @@ class PasswordResetResource(Resource):
         )
         resp_obj = jsonify(resp_obj)
         return make_response(resp_obj, 403)
-
-# ADD the namespaces created to the API
-API.add_namespace(auth_ns)
-API.add_namespace(user_ns)
-API.init_app(APP)

--- a/app/auth.py
+++ b/app/auth.py
@@ -125,7 +125,8 @@ class LoginHandler(Resource):
                     algorithm='HS256'
                 )
                 return jsonify({"message": "Logged in successfully.",
-                                "access_token": token.decode('UTF-8')
+                                "access_token": token.decode('UTF-8'),
+                                "public_id": user.public_id
                                })
             return make_response(jsonify({"message": "Incorrect credentials."}), 401)
         except exec as e: # pragma: no cover

--- a/app/categories.py
+++ b/app/categories.py
@@ -1,0 +1,66 @@
+"""The categories endpoints"""
+from flask import request, jsonify, make_response
+from flask_restplus import Resource
+
+from .auth import authorization_required
+from .models import db, Category, User
+from .serializers import category
+from .restplus import API
+
+categories_ns = API.namespace('category', description='Contains endpoints for recipe categories.')
+
+@categories_ns.route('')
+class CategoryHandler(Resource):
+    """This resource gets all categories or adds a new one."""
+
+    @authorization_required
+    @API.expect(category)
+    def post(current_user, self):
+        """Add Recipe Category"""
+
+        if current_user:
+            # get request data
+            data = request.get_json()
+
+            # check if category exists
+            category = Category.query.filter_by(name=data['category_name']).first()
+                
+            if not category:
+                name = data['category_name']
+                owner = current_user.id
+                description = data['description']
+
+                # Add new category
+                try:
+                    new_category = Category(name, owner, description)
+                    db.session.add(new_category)
+                    db.session.commit()
+                    resp_obj = {
+                        "categories": [dict(
+                            category_name=name,
+                            description=description,
+                            owner=owner
+                        )],
+                        "status": "Success!"
+                    }
+                    resp_obj = jsonify(resp_obj)
+                    return make_response(resp_obj, 201)
+                except:
+                    resp_obj = dict(
+                        message="Some error occured!",
+                        status="Error"
+                    )
+                    resp_obj = jsonify(resp_obj)
+                    return make_response(resp_obj, 501)
+            resp_obj = dict(
+                message="The category already exists!",
+                status="Fail!"
+            )
+            resp_obj = jsonify(resp_obj)
+            return make_response(resp_obj, 400)
+        resp_obj = dict(
+            status="Fail!",
+            message='Login to use this resource!'
+        )
+        resp_obj = jsonify(resp_obj)
+        return make_response(resp_obj, 401)

--- a/app/categories.py
+++ b/app/categories.py
@@ -1,4 +1,5 @@
 """The categories endpoints"""
+import sys
 from flask import request, jsonify, make_response
 from flask_restplus import Resource
 
@@ -24,7 +25,7 @@ class CategoryHandler(Resource):
 
             # check if category exists
             category = Category.query.filter_by(name=data['category_name']).first()
-                
+            print(category, file=sys.stdout)
             if not category:
                 name = data['category_name']
                 owner = current_user.id
@@ -37,8 +38,9 @@ class CategoryHandler(Resource):
                     db.session.commit()
                     resp_obj = {
                         "categories": [dict(
-                            category_name=name,
-                            description=description,
+                            category_id=new_category.id,
+                            category_name=new_category.name,
+                            description=new_category.description,
                             owner=owner
                         )],
                         "status": "Success!"
@@ -58,6 +60,32 @@ class CategoryHandler(Resource):
             )
             resp_obj = jsonify(resp_obj)
             return make_response(resp_obj, 400)
+        resp_obj = dict(
+            status="Fail!",
+            message='Login to use this resource!'
+        )
+        resp_obj = jsonify(resp_obj)
+        return make_response(resp_obj, 401)
+
+    @authorization_required
+    def get(current_user, self):
+        """Returns a list of user's recipe categories"""
+
+        if current_user:
+            all_categories = Category.query.filter_by(user_id=current_user.id)
+            categories = []
+            for cat in all_categories:
+                catg = dict(
+                    category_id=cat.id,
+                    category_name=cat.name,
+                    description=cat.description
+                )
+                categories.append(catg)
+            resp_obj = {
+                "categories": categories,
+                "message": "Success!"
+            }
+            return make_response(jsonify(resp_obj), 200)
         resp_obj = dict(
             status="Fail!",
             message='Login to use this resource!'

--- a/app/categories.py
+++ b/app/categories.py
@@ -140,13 +140,13 @@ class SingleCategoryResource(Resource):
             status="Fail!"
         )
         resp_obj = jsonify(resp_obj)
-        return make_response(resp_obj, 400)
+        return make_response(resp_obj, 404)
 
     @authorization_required
     @API.expect(category)
     def put(current_user, self, id):
         """
-        Returns the specified category
+        Updates the specified category
 
         :param: id (int)
         """
@@ -188,5 +188,39 @@ class SingleCategoryResource(Resource):
             status="Fail!"
         )
         resp_obj = jsonify(resp_obj)
-        return make_response(resp_obj, 400)
+        return make_response(resp_obj, 404)
 
+    @authorization_required
+    def delete(current_user, self, id):
+        """
+        Deletes the specified category
+
+        :param: id (int)
+        """
+        if not current_user:
+            print(current_user, file=sys.stdout)
+            resp_obj = dict(
+                status="Fail!",
+                message='Invalid token. Login to use this resource!'
+            )
+            resp_obj = jsonify(resp_obj)
+            return make_response(resp_obj, 401)
+        
+        # retrieve specified category
+        category = Category.query.filter_by(id=id).first()
+
+        if category:
+            db.session.delete(category)
+            db.session.commit()
+
+            resp_obj = {
+                "status": "Success!"
+            }
+            resp_obj = jsonify(resp_obj)
+            return make_response(resp_obj, 200)
+        resp_obj = dict(
+            message="Sorry, category does not exist!",
+            status="Fail!"
+        )
+        resp_obj = jsonify(resp_obj)
+        return make_response(resp_obj, 404)

--- a/app/categories.py
+++ b/app/categories.py
@@ -25,7 +25,6 @@ class CategoryHandler(Resource):
 
             # check if category exists
             category = Category.query.filter_by(name=data['category_name']).first()
-            print(category, file=sys.stdout)
             if not category:
                 name = data['category_name']
                 owner = current_user.id
@@ -41,7 +40,9 @@ class CategoryHandler(Resource):
                             category_id=new_category.id,
                             category_name=new_category.name,
                             description=new_category.description,
-                            owner=owner
+                            owner=owner,
+                            date_created=new_category.created_on,
+                            date_updated=new_category.updated_on
                         )],
                         "status": "Success!"
                     }
@@ -78,7 +79,9 @@ class CategoryHandler(Resource):
                 catg = dict(
                     category_id=cat.id,
                     category_name=cat.name,
-                    description=cat.description
+                    description=cat.description,
+                    date_created=cat.created_on,
+                    date_updated=cat.updated_on
                 )
                 categories.append(catg)
             resp_obj = {
@@ -92,3 +95,44 @@ class CategoryHandler(Resource):
         )
         resp_obj = jsonify(resp_obj)
         return make_response(resp_obj, 401)
+
+@categories_ns.route('/<int:id>')
+class SingleCategoryResource(Resource):
+    """
+    This resource handles the Read, Update and Delete functionality
+    on a single Recipe category
+    """
+
+    @authorization_required
+    def get(current_user, self, id):
+        """
+        Returns the specified category
+
+        :param: id (int)
+        """
+        if not current_user:
+            print(current_user, file=sys.stdout)
+            resp_obj = dict(
+                status="Fail!",
+                message='Invalid token. Login to use this resource!'
+            )
+            resp_obj = jsonify(resp_obj)
+            return make_response(resp_obj, 401)
+        
+        # retrieve specified category
+        category = Category.query.filter_by(id=id).first()
+
+        if category:
+            resp_obj = {
+                "categories": [dict(
+                    category_id=category.id,
+                    category_name=category.name,
+                    category_description=category.description,
+                    date_created=category.created_on,
+                    date_updated=category.updated_on
+                )],
+                "status": "Success!"
+            }
+            resp_obj = jsonify(resp_obj)
+            return make_response(resp_obj, 200)
+

--- a/app/categories.py
+++ b/app/categories.py
@@ -135,4 +135,58 @@ class SingleCategoryResource(Resource):
             }
             resp_obj = jsonify(resp_obj)
             return make_response(resp_obj, 200)
+        resp_obj = dict(
+            message="Sorry, category does not exist!",
+            status="Fail!"
+        )
+        resp_obj = jsonify(resp_obj)
+        return make_response(resp_obj, 400)
+
+    @authorization_required
+    @API.expect(category)
+    def put(current_user, self, id):
+        """
+        Returns the specified category
+
+        :param: id (int)
+        """
+        if not current_user:
+            print(current_user, file=sys.stdout)
+            resp_obj = dict(
+                status="Fail!",
+                message='Invalid token. Login to use this resource!'
+            )
+            resp_obj = jsonify(resp_obj)
+            return make_response(resp_obj, 401)
+        
+        # retrieve specified category
+        category = Category.query.filter_by(id=id).first()
+
+        if category:
+            # Get request data
+            data = request.get_json()
+
+            # Update category data
+            category.name = data['category_name']
+            category.description = data['description']
+            db.session.commit()
+
+            resp_obj = {
+                "categories": [dict(
+                    category_id=category.id,
+                    category_name=category.name,
+                    category_description=category.description,
+                    date_created=category.created_on,
+                    date_updated=category.updated_on
+                )],
+                "status": "Success!"
+            }
+            resp_obj = jsonify(resp_obj)
+            return make_response(resp_obj, 200)
+        resp_obj = dict(
+            message="Sorry, category does not exist!",
+            status="Fail!"
+        )
+        resp_obj = jsonify(resp_obj)
+        return make_response(resp_obj, 400)
 

--- a/app/models.py
+++ b/app/models.py
@@ -34,6 +34,10 @@ class Category(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False)
     name = db.Column(db.String(40), unique=True, nullable=False)
     description = db.Column(db.String(40), unique=True, nullable=False)
+    created_on = db.Column(db.DateTime, default=db.func.current_timestamp())
+    updated_on = db.Column(
+        db.DateTime, default=db.func.current_timestamp(), onupdate=db.func.current_timestamp()
+    )
     recipes = db.relationship('Recipe', backref='category', lazy='dynamic')
 
     def __init__(self, name, owner, description):
@@ -54,6 +58,10 @@ class Recipe(db.Model):
     name = db.Column(db.String(40), unique=True, nullable=False)
     ingredients = db.Column(db.String(200), nullable=False)
     description = db.Column(db.String(500), nullable=False)
+    created_on = db.Column(db.DateTime, default=db.func.current_timestamp())
+    updated_on = db.Column(
+        db.DateTime, default=db.func.current_timestamp(), onupdate=db.func.current_timestamp()
+    )
 
 class BlacklistToken(db.Model):
     """Blacklisted tokens Model"""

--- a/app/models.py
+++ b/app/models.py
@@ -36,6 +36,11 @@ class Category(db.Model):
     description = db.Column(db.String(40), unique=True, nullable=False)
     recipes = db.relationship('Recipe', backref='category', lazy='dynamic')
 
+    def __init__(self, name, owner, description):
+        self.name = name
+        self.user_id = owner
+        self.description = description
+
 class Recipe(db.Model):
     """Recipes Model"""
 

--- a/app/parsers.py
+++ b/app/parsers.py
@@ -3,4 +3,4 @@
 from flask_restplus import reqparse
 
 auth_header = reqparse.RequestParser()
-auth_header.add_argument('access_token', type=str, location='headers')
+auth_header.add_argument('Authorization', type=str, location='headers', required=True)

--- a/app/restplus.py
+++ b/app/restplus.py
@@ -1,6 +1,16 @@
 """RESTPLus API init"""
 from flask_restplus import Api
 
+# Setup authorization
+authorization = {
+    'apiKey': {
+        'type': 'apiKey',
+        'in': 'header',
+        'name': 'Authorization'
+    }
+}
+
 API = Api( version='1.0', title="Yummy REST",
-    description="REST API implementation of the Yummy Recipes using Flask and PostgreSQL"
+    description="REST API implementation of the Yummy Recipes using Flask and PostgreSQL",
+    authorizations=authorization
 )

--- a/app/serializers.py
+++ b/app/serializers.py
@@ -20,3 +20,8 @@ password_reset = API.model('Reset password.', {
     'current_password': fields.String(required=True, description='Current password.'),
     'new_password': fields.String(required=True, description='New password.')
 })
+
+category = API.model('Recipe Category', {
+    'category_name': fields.String(required=True, description='Name of the recipe category'),
+    'description': fields.String(required=True, description='A slight description of the category')
+})

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -22,6 +22,12 @@ test_category = json.dumps(dict(
     description="All my cookies recipes."
 ))
 
+# Test Category update details
+test_category_update = json.dumps(dict(
+    category_name="Pies",
+    description="All my pie recipes."
+))
+
 # Register test user
 def register_user(self):
         """Registers a test user"""

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -3,14 +3,35 @@ This are helper methods/functions shared across test cases
 """
 from flask import json
 
-# Register user helper
+# Registration details
+user_details = dict(
+    email="isaac@yum.my",
+    username="isaac",
+    password="123456"
+)
 
-def register_user(self, email, username, password):
+# Login details
+login_details = dict(
+    email=user_details['email'],
+    password=user_details['password']
+)
+
+# Test Category details
+test_category = json.dumps(dict(
+    category_name="Cookies",
+    description="All my cookies recipes."
+))
+
+# Register test user
+def register_user(self):
         """Registers a test user"""
         return self.client.post('/auth/register',
-                                  data=json.dumps(dict(
-                                      email=email,
-                                      username=username,
-                                      password=password
-                                  )), content_type="application/json"
-                                 )
+                                  data=json.dumps(user_details), content_type='application/json'
+                                )
+
+# Login test user
+def login_user(self):
+    """Logs a user in"""
+    return self.client.post('/auth/login',
+                              data=json.dumps(login_details), content_type='application/json'
+                            )

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -36,7 +36,7 @@ class AuthNSTestCase(BaseTestCase):
     def test_registration(self):
         """ Test for user registration """
         with self.client:
-            response = register_user(self, "isaac@yum.my", "isaac", "123456")
+            response = register_user(self)
             data = json.loads(response.data.decode())
             self.assertTrue(data['message'] == 'Registered successfully!')
             self.assertTrue(response.content_type == 'application/json')
@@ -52,12 +52,12 @@ class AuthNSTestCase(BaseTestCase):
         db.session.add(user)
         db.session.commit()
         with self.client:
-            response = register_user(self, "isaac@yum.my", "Isaac" ,"123456")
+            response = register_user(self)
             data = json.loads(response.data.decode())
             self.assertTrue(
                 data['message'] == 'User already exists. Please Log in instead.')
             self.assertTrue(response.content_type == 'application/json')
-            self.assertEqual(response.status_code, 202)
+            self.assertEqual(response.status_code, 400)
 
     def test_login_without_credentials(self):
         """Test login resource without any credentials supplied"""
@@ -75,7 +75,7 @@ class AuthNSTestCase(BaseTestCase):
         """ Test for login of registered-user login """
         with self.client:
             # user registration
-            register_resp = register_user(self, "isaac@yum.my", "isaac", "123456")
+            register_resp = register_user(self)
             data_register = json.loads(register_resp.data.decode())
             self.assertTrue(
                 data_register['message'] == 'Registered successfully!'
@@ -117,7 +117,7 @@ class AuthNSTestCase(BaseTestCase):
         """ Test for login of registered-user login """
         with self.client:
             # user registration
-            register_resp = register_user(self, "isaac@yum.my", "isaac", "123456")
+            register_resp = register_user(self)
             data_register = json.loads(register_resp.data.decode())
             self.assertTrue(
                 data_register['message'] == 'Registered successfully!'
@@ -142,7 +142,7 @@ class AuthNSTestCase(BaseTestCase):
         """ Test for logout before token expires """
         with self.client:
             # user registration
-            register_resp = register_user(self, "isaac@yum.my", "isaac", "123456")
+            register_resp = register_user(self)
             data_register = json.loads(register_resp.data.decode())
             self.assertTrue(
                 data_register['message'] == 'Registered successfully!')
@@ -166,7 +166,7 @@ class AuthNSTestCase(BaseTestCase):
             response = self.client.post(
                 '/auth/logout',
                 headers=dict(
-                    access_token=json.loads(
+                    Authorization=json.loads(
                         login_resp.data.decode()
                     )['access_token']
                 )
@@ -180,7 +180,7 @@ class AuthNSTestCase(BaseTestCase):
         """ Test for logout after a valid token gets blacklisted """
         with self.client:
             # user registration
-            register_resp = register_user(self, "isaac@yum.my", "isaac", "123456")
+            register_resp = register_user(self)
             data_register = json.loads(register_resp.data.decode())
             self.assertTrue(
                 data_register['message'] == 'Registered successfully!')
@@ -209,7 +209,7 @@ class AuthNSTestCase(BaseTestCase):
             response = self.client.post(
                 '/auth/logout',
                 headers=dict(
-                    access_token=json.loads(
+                    Authorization=json.loads(
                         login_resp.data.decode()
                     )['access_token']
                 )
@@ -227,7 +227,7 @@ class AuthNSTestCase(BaseTestCase):
         """
         with self.client:
             # user registration
-            register_user(self, "isaac@yum.my", "isaac", "123456")
+            register_user(self)
             # login user
             self.client.post(
                 '/auth/login',

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -1,0 +1,76 @@
+"""
+This Test suite houses the category endpoint tests
+"""
+import json
+# from werkzeug.datastructures import Headers
+from flask_testing import TestCase
+from app import APP
+from app.models import db, Category
+from .test_auth import BaseTestCase
+
+# Test Helpers
+from .helpers import register_user, login_user, test_category
+
+class CategoryTestCase(BaseTestCase):
+    """This class contains the tests for the categories namespace"""
+
+    def test_category_creation(self):
+        """Ensures category can be created"""
+
+        with self.client:
+            register_resp = register_user(self)
+            self.assertEqual(register_resp.status_code, 201)
+            login_resp = login_user(self)
+            self.assertEqual(login_resp.status_code, 200)
+            # h = Headers()
+            # h.add("Authorization", login_resp_data['access_token'] )
+            access_token = json.loads(login_resp.data.decode())['access_token']
+            response = self.client.post('/category', headers=dict(
+                Authorization=access_token
+            ), data=test_category, content_type='application/json')
+            response_data = json.loads(response.data.decode())
+            self.assertEqual(response.status_code, 201)
+            self.assertEqual(response_data['status'], "Success!")
+
+    def test_category_duplication(self):
+        """Ensures category can be created"""
+
+        with self.client:
+            register_resp = register_user(self)
+            self.assertEqual(register_resp.status_code, 201)
+            login_resp = login_user(self)
+            self.assertEqual(login_resp.status_code, 200)
+            access_token = json.loads(login_resp.data.decode())['access_token']
+            response = self.client.post('/category', headers=dict(
+                Authorization=access_token
+            ), data=test_category, content_type='application/json')
+            response_data = json.loads(response.data.decode())
+            self.assertEqual(response.status_code, 201)
+            self.assertEqual(response_data['status'], "Success!")
+            response = self.client.post('/category', headers=dict(
+                Authorization=access_token
+            ), data=test_category, content_type='application/json')
+            response_data = json.loads(response.data.decode())
+            self.assertEqual(response.status_code, 400)
+            self.assertEqual(response_data['status'], "Fail!")
+            self.assertEqual(response_data['message'], "The category already exists!")
+
+    def test_unauthorized_category_creation(self):
+        """Ensures that only logged in users can create cartegories"""
+
+        with self.client:
+            # Ensure that resource can not be accessed without an access token
+            response = self.client.post('/category', data=test_category, content_type='application/json')
+            response_data = json.loads(response.data.decode())
+            self.assertEqual(response.status_code, 401)
+            self.assertEqual(response_data['status'], "Fail!")
+            self.assertEqual(response_data['message'], "Please provide an access token!")
+            # Ensure that access is only granted when the right access token is provided (on login)
+            response = self.client.post(
+                '/category', headers=dict(Authorization="some458273487WRGWU"),
+                data=test_category, content_type='application/json'
+            )
+            response_data = json.loads(response.data.decode())
+            self.assertEqual(response.status_code, 401)
+            self.assertEqual(response_data['status'], "Fail!")
+            self.assertEqual(response_data['message'], "Login to use this resource!")

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -10,7 +10,7 @@ from app.models import db, Category
 from .test_auth import BaseTestCase
 
 # Test Helpers
-from .helpers import register_user, login_user, test_category
+from .helpers import register_user, login_user, test_category, test_category_update
 
 class CategoryTestCase(BaseTestCase):
     """This class contains the tests for the categories namespace"""
@@ -188,3 +188,81 @@ class CategoryTestCase(BaseTestCase):
             self.assertEqual(response_data['status'], "Success!")
             self.assertTrue(len(response_data['categories']) == 1)
             self.assertEqual(response_data['categories'][0]['category_name'], "Cookies")
+
+            # Attempt retrieval of non-existent category
+            response = test_client.get(
+                '/category/2', headers=auth_header, content_type='application/json'
+            )
+            self.assertEqual(response.status_code, 400)
+            response_data = json.loads(response.data.decode())
+            print(response_data, file=sys.stdout)
+            self.assertEqual(response_data['status'], "Fail!")
+            self.assertEqual(response_data['message'], "Sorry, category does not exist!")
+
+    def test_single_category_update(self):
+        """Ensures that a single category can be retrieved"""
+
+        with self.client as test_client:
+            # Set up
+            register_resp = register_user(self)
+            self.assertEqual(register_resp.status_code, 201)
+            login_resp = login_user(self)
+            self.assert200(login_resp, "User not logged in!")
+            access_token = json.loads(login_resp.data.decode())['access_token']
+            auth_header = dict(
+                Authorization=access_token
+            )
+            # Add test category
+            cat_create_resp = test_client.post(
+                '/category', headers=auth_header, data=test_category,
+                content_type='application/json'
+            )
+            cat_create_resp_data = json.loads(cat_create_resp.data.decode())
+            self.assertEqual(cat_create_resp.status_code, 201)
+            self.assertEqual(cat_create_resp_data['categories'][0]['category_id'], 1)
+
+            # Ensure that the resource is private
+            # Attempt Access with no token
+            response = test_client.put(
+                '/category/1', data=test_category_update,
+                content_type='application/json'
+            )
+            self.assertEqual(response.status_code, 401)
+            response_data = json.loads(response.data.decode())
+            self.assertEqual(response_data['status'], "Fail!")
+            self.assertEqual(response_data['message'], "Please provide an access token!")
+            
+            # Attempt access with invalid token
+            x_access_token = "5u32905ugnw9e8ut025u2"
+            x_auth_header = dict(Authorization=x_access_token)
+            response = test_client.put(
+                '/category/1', headers=x_auth_header,
+                data=test_category_update, content_type='application/json'
+            )
+            self.assertEqual(response.status_code, 401)
+            response_data = json.loads(response.data.decode())
+            self.assertEqual(response_data['status'], "Fail!")
+            self.assertEqual(response_data['message'], "Invalid token. Login to use this resource!")
+
+            # Ensure single category can be retrieved
+            response = test_client.put(
+                '/category/1', headers=auth_header,
+                data=test_category_update, content_type='application/json'
+            )
+            self.assertEqual(response.status_code, 200)
+            response_data = json.loads(response.data.decode())
+            print(response_data, file=sys.stdout)
+            self.assertEqual(response_data['status'], "Success!")
+            self.assertTrue(len(response_data['categories']) == 1)
+            self.assertEqual(response_data['categories'][0]['category_name'], "Pies")
+
+            # Attempt update of non-existent category
+            response = test_client.put(
+                '/category/2', headers=auth_header,
+                data=test_category_update, content_type='application/json'
+            )
+            self.assertEqual(response.status_code, 400)
+            response_data = json.loads(response.data.decode())
+            print(response_data, file=sys.stdout)
+            self.assertEqual(response_data['status'], "Fail!")
+            self.assertEqual(response_data['message'], "Sorry, category does not exist!")

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -1,6 +1,7 @@
 """
 This Test suite houses the category endpoint tests
 """
+import sys
 import json
 # from werkzeug.datastructures import Headers
 from flask_testing import TestCase
@@ -36,17 +37,21 @@ class CategoryTestCase(BaseTestCase):
         """Ensures category can be created"""
 
         with self.client:
+            # Register and login test user
             register_resp = register_user(self)
             self.assertEqual(register_resp.status_code, 201)
             login_resp = login_user(self)
             self.assertEqual(login_resp.status_code, 200)
+            # Retrieve access token
             access_token = json.loads(login_resp.data.decode())['access_token']
+            # Create the category
             response = self.client.post('/category', headers=dict(
                 Authorization=access_token
             ), data=test_category, content_type='application/json')
             response_data = json.loads(response.data.decode())
             self.assertEqual(response.status_code, 201)
             self.assertEqual(response_data['status'], "Success!")
+            # Attempt a duplication of the same category
             response = self.client.post('/category', headers=dict(
                 Authorization=access_token
             ), data=test_category, content_type='application/json')
@@ -74,3 +79,60 @@ class CategoryTestCase(BaseTestCase):
             self.assertEqual(response.status_code, 401)
             self.assertEqual(response_data['status'], "Fail!")
             self.assertEqual(response_data['message'], "Login to use this resource!")
+
+    def test_category_view_unregistered_user(self):
+        """Ensure that only authorized users can view categories"""
+
+        with self.client:
+            # When user provides no access token
+            response = self.client.get('/category', content_type='application/json')
+            response_data = json.loads(response.data.decode())
+            self.assertEqual(response.status_code, 401)
+            self.assertTrue(response_data['status'] == "Fail!")
+            self.assertTrue(response_data['message'] == "Please provide an access token!")
+            # When user provides invalid access token
+            access_token = "some_funny_token_/$tring/"
+            auth_header = dict(Authorization=access_token)
+            response = self.client.get(
+                '/category', headers=auth_header, content_type='application/json'
+            )
+            response_data = json.loads(response.data.decode())
+            self.assertEqual(response.status_code, 401)
+            self.assertTrue(response_data['status'] == "Fail!")
+            self.assertEqual(response_data['message'], "Login to use this resource!")
+
+    def test_category_view_registered_user(self):
+        """Ensure a registered/logged in user can view their categories"""
+
+        with self.client as test_client:
+            register_resp = register_user(self)
+            self.assertEqual(register_resp.status_code, 201)
+            login_resp = login_user(self)
+            self.assert200(login_resp, "User not logged in")
+            login_resp_data = json.loads(login_resp.data.decode())
+            auth_header = dict(
+                Authorization=login_resp_data['access_token']
+            )
+            response = test_client.get(
+                '/category', headers=auth_header, content_type='application/json'
+            )
+            self.assertEqual(response.status_code, 200)
+            response_data = json.loads(response.data.decode())
+            print(response_data, file=sys.stdout)
+            self.assertTrue(response_data['message'] == "Success!")
+            self.assertTrue(len(response_data['categories']) == 0)
+            # Create a test category
+            category_resp = self.client.post(
+                '/category',
+                headers=auth_header,
+                data=test_category,
+                content_type='application/json'
+            )
+            self.assertEqual(category_resp.status_code, 201)
+            # Ensure category is added
+            response = test_client.get(
+                '/category', headers=auth_header, content_type='application/json'
+            )
+            self.assert200(response, "Categories not retrieved")
+            response_data = json.loads(response.data.decode())
+            self.assertTrue(len(response_data['categories']) == 1)


### PR DESCRIPTION
## What this PR is for

The API's category endpoints are protected endpoints that are defined under the `/category` namespace
There are five endpoints which handle new category creation, view for all users categories, single category view, update and delete.
The PR also fixes the note issue of repetitive authorisation by adding an apiKey authorisation feature configuration in commit [9cb59e8](https://github.com/indungu/yummy-rest/commit/9cb59e8362bf9577776e4d9cf0d5c746fbc83163).

![image](https://user-images.githubusercontent.com/30072633/34293865-38bf5a2a-e717-11e7-8f65-01d530f691c4.png)

The PR also fixes another of the noted issues on the `/auth/reset-password` endpoint. Previously the user could not reset their password since they were required to provide a public id which was never output.
To that effect, the users public id is provided to the user on login as shown below.
![image](https://user-images.githubusercontent.com/30072633/34294022-c6b7a954-e717-11e7-83be-e208f5c0d601.png)


## Feature Stories (Pivotal Tracker)
category creation[#153856578](https://www.pivotaltracker.com/story/show/153856578)
categories view [#153855416](https://www.pivotaltracker.com/story/show/153855416)
single category view [#153856742](https://www.pivotaltracker.com/story/show/153856742)
single category update [#153857445](https://www.pivotaltracker.com/story/show/153857445)
single category delete [#153857686](https://www.pivotaltracker.com/story/show/153857686) 

### What to review

1. Ensure the tasks listed on the story are  well and fully completed.
2. Ensure that the acceptance criteria is met.
3. Confirm the `Dev Notes` were adhered to.

### How to review

#### Installation

> Prerequisites: PostgreSQL>=9.6, Python>=3.6

```bash
$ createdb -U postgres yummy_rest # Set up the database first:
$ createdb -U postgres yummy_rest_test
$ git clone -b dev-category https://github.com/indungu/yummy-rest # Clone repo on required branch
$ cd yummy-recipes
$ virtualenv venv
$ source venv/bin/activate
(venv)...$ pip install -r requirements.txt
(venv)...$ python manage.py db init # create the relations
(venv)...$ python manage.py db migrate 
(venv)...$ python manage.py db upgrade 
(venv)...$ pytest # Ensure all test are passing
(venv)...$ python run.py
 ```

## Noted issues

> All the features seem to be working to required. The only problem is when user provides an letter, string or special character the category_id, the server is hit with malformed URL path and throws the builtin prompt which is in `html` instead of `json`. 
