### PR TITLE
Recipes endpoints (CRUD features)

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,6 +2,10 @@
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
 
+# Linting exception
+# pylint: disable=C0103
+# pylint: disable=C0413
+
 # local import
 from instance.config import app_config
 
@@ -13,6 +17,7 @@ APP = Flask(__name__, instance_relative_config=True)
 APP.config.from_object(app_config['development'])
 db.init_app(APP)
 
+# Import and add namespaces for the endpoints
 from app.restplus import API
 from app.auth import auth_ns
 from app.categories import categories_ns

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -16,7 +16,9 @@ db.init_app(APP)
 from app.restplus import API
 from app.auth import auth_ns
 from app.categories import categories_ns
+from app.recipes import recipes_ns
 
 API.add_namespace(auth_ns)
 API.add_namespace(categories_ns)
+API.add_namespace(recipes_ns)
 API.init_app(APP)

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,5 +1,4 @@
 """The API routes"""
-import sys
 from functools import wraps
 from datetime import datetime, timedelta
 from werkzeug.security import check_password_hash, generate_password_hash
@@ -157,14 +156,11 @@ class LogoutHandler(Resource):
         Logout route
         """
         access_token = request.headers.get('Authorization')
-        print(access_token, file=sys.stdout)
         if access_token:
             result = decode_access_token(access_token)
-            print(result, file=sys.stdout)
             if not isinstance(result, str):
                 # mark the token as blacklisted
                 blacklisted_token = BlacklistToken(access_token)
-                print(blacklisted_token, file=sys.stdout)
                 try:
                     # insert the token
                     db.session.add(blacklisted_token)
@@ -173,7 +169,6 @@ class LogoutHandler(Resource):
                         status="success",
                         message="Logged out successfully."
                     )
-                    print(jsonify(response_obj), file=sys.stdout)
                     return make_response(jsonify(response_obj), 200)
                 except Exception as e:
                     resp_obj = {
@@ -186,7 +181,6 @@ class LogoutHandler(Resource):
                     status="fail",
                     message=result
                 )
-                print(jsonify(resp_obj), file=sys.stdout)
                 return make_response(jsonify(resp_obj), 401)
         else:
             response_obj = {

--- a/app/auth.py
+++ b/app/auth.py
@@ -20,7 +20,8 @@ auth_ns = API.namespace('auth', description="Authentication/Authorization operat
 def decode_access_token(access_token):
     """
     Validates the user access token
-    :param access_token:
+
+    :param str access_token: The access token tp be decoded
     :return: integer|string
     """
     try:
@@ -89,7 +90,7 @@ class RegisterHandler(Resource):
                 db.session.add(new_user)
                 db.session.commit()
                 return make_response(jsonify({'message': 'Registered successfully!'}), 201)
-            except Exception as e: # pragma: no cover
+            except Exception as e: 
                 response = {"message": "Some error occured. Please retry."}
                 return make_response(jsonify(response), 501)
         else:
@@ -107,7 +108,7 @@ class LoginHandler(Resource):
         User Login/SignIn route
         """
         login_info = request.get_json()
-        if not login_info: # pragma: no cover
+        if not login_info: 
             return make_response(jsonify({'message': 'Input payload validation failed'}), 401)
         try:
             user = User.query.filter_by(email=login_info['email']).first()
@@ -129,7 +130,7 @@ class LoginHandler(Resource):
                                 "public_id": user.public_id
                                })
             return make_response(jsonify({"message": "Incorrect credentials."}), 401)
-        except exec as e: # pragma: no cover
+        except exec as e: 
             print(e)
             return make_response(jsonify({"message": "An error occurred. Please try again."}), 501)
 
@@ -162,7 +163,7 @@ class LogoutHandler(Resource):
                     )
                     print(jsonify(response_obj), file=sys.stdout)
                     return make_response(jsonify(response_obj), 200)
-                except Exception as e: # pragma: no cover
+                except Exception as e: 
                     resp_obj = {
                         'status': 'fail',
                         'message': e

--- a/app/categories.py
+++ b/app/categories.py
@@ -4,11 +4,14 @@ from flask import request, jsonify, make_response
 from flask_restplus import Resource
 
 from .auth import authorization_required
-from .models import db, Category, User
+from .models import db, Category
 from .serializers import category
 from .restplus import API
 
-categories_ns = API.namespace('category', description='Contains endpoints for recipe categories.')
+categories_ns = API.namespace(
+    'category', description='Contains endpoints for recipe categories.',
+    path='/category'
+)
 
 @categories_ns.route('')
 class CategoryHandler(Resource):

--- a/app/categories.py
+++ b/app/categories.py
@@ -8,6 +8,17 @@ from .models import db, Category
 from .serializers import category
 from .restplus import API
 
+# Linting exceptions
+
+# pylint: disable=C0103
+# pylint: disable=W0702
+# pylint: disable=W0703
+# pylint: disable=W0613
+# pylint: disable=W0622
+# pylint: disable=E1101
+# pylint: disable=E0213
+# pylint: disable=R0201
+
 categories_ns = API.namespace(
     'category', description='Contains endpoints for recipe categories.',
     path='/category'
@@ -27,8 +38,10 @@ class CategoryHandler(Resource):
             data = request.get_json()
 
             # check if category exists
-            category = Category.query.filter_by(name=data['category_name']).first()
-            if not category:
+            existing_category = current_user.categories.filter_by(
+                name=data['category_name']
+            ).first()
+            if not existing_category:
                 name = data['category_name']
                 owner = current_user.id
                 description = data['description']
@@ -121,18 +134,18 @@ class SingleCategoryResource(Resource):
             )
             resp_obj = jsonify(resp_obj)
             return make_response(resp_obj, 401)
-        
-        # retrieve specified category
-        category = Category.query.filter_by(id=id).first()
 
-        if category:
+        # retrieve specified category
+        specified_category = Category.query.filter_by(id=id).first()
+
+        if specified_category:
             resp_obj = {
                 "categories": [dict(
-                    category_id=category.id,
-                    category_name=category.name,
-                    category_description=category.description,
-                    date_created=category.created_on,
-                    date_updated=category.updated_on
+                    category_id=specified_category.id,
+                    category_name=specified_category.name,
+                    category_description=specified_category.description,
+                    date_created=specified_category.created_on,
+                    date_updated=specified_category.updated_on
                 )],
                 "status": "Success!"
             }
@@ -161,26 +174,26 @@ class SingleCategoryResource(Resource):
             )
             resp_obj = jsonify(resp_obj)
             return make_response(resp_obj, 401)
-        
-        # retrieve specified category
-        category = Category.query.filter_by(id=id).first()
 
-        if category:
+        # retrieve specified category
+        specified_category = current_user.categories.filter_by(id=id).first()
+
+        if specified_category:
             # Get request data
             data = request.get_json()
 
             # Update category data
-            category.name = data['category_name']
-            category.description = data['description']
+            specified_category.name = data['category_name']
+            specified_category.description = data['description']
             db.session.commit()
 
             resp_obj = {
                 "categories": [dict(
-                    category_id=category.id,
-                    category_name=category.name,
-                    category_description=category.description,
-                    date_created=category.created_on,
-                    date_updated=category.updated_on
+                    category_id=specified_category.id,
+                    category_name=specified_category.name,
+                    category_description=specified_category.description,
+                    date_created=specified_category.created_on,
+                    date_updated=specified_category.updated_on
                 )],
                 "status": "Success!"
             }
@@ -208,12 +221,12 @@ class SingleCategoryResource(Resource):
             )
             resp_obj = jsonify(resp_obj)
             return make_response(resp_obj, 401)
-        
-        # retrieve specified category
-        category = Category.query.filter_by(id=id).first()
 
-        if category:
-            db.session.delete(category)
+        # retrieve specified category
+        specified_category = current_user.categories.filter_by(id=id).first()
+
+        if specified_category:
+            db.session.delete(specified_category)
             db.session.commit()
 
             resp_obj = {

--- a/app/models.py
+++ b/app/models.py
@@ -15,8 +15,8 @@ class User(db.Model):
     email = db.Column(db.String(80), unique=True, nullable=False)
     username = db.Column(db.String(80), unique=True, nullable=False)
     password = db.Column(db.String(120), nullable=False)
-    categories = db.relationship('Category', backref='user', lazy='dynamic')
-    recipes = db.relationship('Recipe', backref='user', lazy='dynamic')
+    categories = db.relationship('Category', backref='owner', cascade="all, delete-orphan", lazy='dynamic')
+    recipes = db.relationship('Recipe', backref='owner', cascade="all, delete-orphan", lazy='dynamic')
 
     def __init__(self, email, username, password):
         self.public_id = uuid.uuid4()
@@ -38,7 +38,9 @@ class Category(db.Model):
     updated_on = db.Column(
         db.DateTime, default=db.func.current_timestamp(), onupdate=db.func.current_timestamp()
     )
-    recipes = db.relationship('Recipe', backref='category', lazy='dynamic')
+    recipes = db.relationship(
+        'Recipe', backref='category', cascade="all, delete-orphan", lazy='dynamic'
+    )
 
     def __init__(self, name, owner, description):
         self.name = name

--- a/app/models.py
+++ b/app/models.py
@@ -2,8 +2,13 @@
 import uuid
 from datetime import datetime
 from werkzeug.security import generate_password_hash
-from flask_sqlalchemy import SQLAlchemy
 from app import db
+
+# Linting exceptions
+
+# pylint: disable=E1101
+# pylint: disable=C0103
+# pylint: disable=R0903
 
 class User(db.Model):
     """User model"""
@@ -15,8 +20,12 @@ class User(db.Model):
     email = db.Column(db.String(80), unique=True, nullable=False)
     username = db.Column(db.String(80), unique=True, nullable=False)
     password = db.Column(db.String(120), nullable=False)
-    categories = db.relationship('Category', backref='owner', cascade="all, delete-orphan", lazy='dynamic')
-    recipes = db.relationship('Recipe', backref='owner', cascade="all, delete-orphan", lazy='dynamic')
+    categories = db.relationship(
+        'Category', backref='owner', cascade="all, delete-orphan", lazy='dynamic'
+    )
+    recipes = db.relationship(
+        'Recipe', backref='owner', cascade="all, delete-orphan", lazy='dynamic'
+    )
 
     def __init__(self, email, username, password):
         self.public_id = uuid.uuid4()
@@ -77,16 +86,15 @@ class BlacklistToken(db.Model):
     def __init__(self, token):
         self.token = token
         self.blacklisted_on = datetime.utcnow()
-    
+
     def __repr__(self):
         return '<Token: {} Blacklist_date {}>'.format(self.token, self.blacklisted_on)
 
     @staticmethod
     def check_blacklisted(token):
-        # check whether auth token has been blacklisted
-        exists = BlacklistToken.query.filter_by(token=str(token)).first()
-        if exists:
-            return True
-        else:
-            return False
+        """
+        Check whether access token has already been blacklisted
+        """
 
+        exists = BlacklistToken.query.filter_by(token=str(token)).first()
+        return bool(exists)

--- a/app/parsers.py
+++ b/app/parsers.py
@@ -2,5 +2,9 @@
 
 from flask_restplus import reqparse
 
+# Linting exceptions
+
+# pylint: disable=C0103
+
 auth_header = reqparse.RequestParser()
 auth_header.add_argument('Authorization', type=str, location='headers', required=True)

--- a/app/recipes.py
+++ b/app/recipes.py
@@ -1,0 +1,81 @@
+"""The recipes endpoints"""
+import sys
+from flask import request, jsonify, make_response
+from flask_restplus import Resource
+
+from .auth import authorization_required
+from .models import db, Recipe
+from .serializers import recipe
+from  .restplus import API
+
+recipes_ns = API.namespace(
+    'recipes', description='The enpoints for recipe manipulation',
+    path='/category/<int:category_id>/recipes'
+)
+
+@recipes_ns.route('')
+class GeneralRecipesHandler(Resource):
+    """
+    This class defines the endpoints for creating a single recipe
+    in a particular category or retrieving all the recipes in said
+    category
+    """
+
+    @authorization_required
+    @API.expect(recipe)
+    def post(current_user, self, category_id):
+        """
+        Create a recipe in the specified category
+
+        :param int category_id: The id of the category to which recipe should be added
+        """
+
+        if not current_user:
+            resp_obj = dict(
+                status='Fail!',
+                message='Invalid token. Login to use this resource!'
+            )
+            resp_obj = jsonify(resp_obj)
+            return make_response(resp_obj, 401)
+
+        data = request.get_json()        
+        category = current_user.categories.filter_by(id=category_id).first()
+        if category:
+            new_recipe = Recipe(
+                name=data['recipe_name'],
+                category_id=category_id,
+                user_id=current_user.id,
+                ingredients=data['ingredients'],
+                description=data['description']
+            )
+            recipe = category.recipes.filter_by(name=data['recipe_name']).first()
+            if not recipe:    
+                db.session.add(new_recipe)
+                db.session.commit()
+
+                resp_obj = {
+                    'status': 'Success!',
+                    'recipes': [dict(
+                        recipe_name=new_recipe.name,
+                        recipe_ingredients=new_recipe.ingredients,
+                        recipe_description=new_recipe.description,
+                        category=new_recipe.category_id,
+                        date_created=new_recipe.created_on,
+                        date_updated=new_recipe.updated_on,
+                        owner=new_recipe.user_id
+                    )]
+                }
+                resp_obj = jsonify(resp_obj)
+                return make_response(resp_obj, 201)
+            resp_obj = dict(
+                status='Fail!',
+                message='Recipe already exists!'
+            )
+            resp_obj = jsonify(resp_obj)
+            return make_response(resp_obj, 400)
+        resp_obj = dict(
+            status='Fail!',
+            message='Invalid category!'
+        )
+        resp_obj = jsonify(resp_obj)
+        return make_response(resp_obj, 400)

--- a/app/recipes.py
+++ b/app/recipes.py
@@ -9,9 +9,11 @@ from .serializers import recipe
 from .restplus import API
 
 # Linting exceptions
+
 # pylint: disable=C0103
 # pylint: disable=E0213
 # pylint: disable=E1101
+# pylint: disable=W0613
 
 recipes_ns = API.namespace(
     'recipes', description='The enpoints for recipe manipulation',
@@ -118,13 +120,13 @@ class GeneralRecipesHandler(Resource):
                 return make_response(resp_obj, 200)
 
             user_recipes = []
-            for recipe in recipes:
+            for a_recipe in recipes:
                 rec = dict(
-                    recipe_name=recipe.name,
-                    recipe_ingredients=recipe.ingredients,
-                    recipe_description=recipe.description,
-                    date_created=recipe.created_on,
-                    date_modified=recipe.updated_on,
+                    recipe_name=a_recipe.name,
+                    recipe_ingredients=a_recipe.ingredients,
+                    recipe_description=a_recipe.description,
+                    date_created=a_recipe.created_on,
+                    date_modified=a_recipe.updated_on,
                 )
                 user_recipes.append(rec)
 

--- a/app/recipes.py
+++ b/app/recipes.py
@@ -1,5 +1,4 @@
 """The recipes endpoints"""
-import sys
 from flask import request, jsonify, make_response
 from flask_restplus import Resource
 
@@ -310,7 +309,6 @@ class SingleRecipeHandler(Resource):
                 "message": "Recipe " + name + " was deleted successfully!"
             }
             resp_obj = jsonify(resp_obj)
-            print(resp_obj.data.decode(), file=sys.stdout)
             return make_response(resp_obj, 200)
         # When an invalid category id is provided
         resp_obj = dict(

--- a/app/recipes.py
+++ b/app/recipes.py
@@ -79,3 +79,60 @@ class GeneralRecipesHandler(Resource):
         )
         resp_obj = jsonify(resp_obj)
         return make_response(resp_obj, 400)
+
+    @authorization_required
+    def get(current_user, self, category_id):
+        """
+        Retrives a list of the recipes for the category
+
+        :param int category_id: The id of the category whose recipes to be displayed
+
+        :return str status: The status of the request (Success, Fail)
+
+        :return list recipes: The recipes in the category
+        """
+
+        if not current_user:
+            resp_obj = dict(
+                status='Fail!',
+                message='Invalid token. Login to use this resource!'
+            )
+            resp_obj = jsonify(resp_obj)
+            return make_response(resp_obj, 401)
+
+        category = current_user.categories.filter_by(id=category_id).first()
+        if category:
+            recipes = category.recipes.all()
+
+            if not recipes:
+                resp_obj = dict(
+                    status='Success!',
+                    message='No recipes added to this category yet!'
+                )
+                resp_obj = jsonify(resp_obj)
+                return make_response(resp_obj, 200)
+
+            user_recipes = []
+            for recipe in recipes:
+                rec = dict(
+                    recipe_name=recipe.name,
+                    recipe_ingredients=recipe.ingredients,
+                    recipe_description=recipe.description,
+                    date_created=recipe.created_on,
+                    date_modified=recipe.updated_on
+                )
+                user_recipes.append(rec)
+
+            resp_obj = {
+                "status": "Success!",
+                "recipes": user_recipes
+            }
+            resp_obj = jsonify(resp_obj)
+            return make_response(resp_obj, 200)
+        resp_obj = dict(
+            status='Fail!',
+            message='Invalid category!'
+        )
+        resp_obj = jsonify(resp_obj)
+        return make_response(resp_obj, 400)
+

--- a/app/recipes.py
+++ b/app/recipes.py
@@ -1,4 +1,5 @@
 """The recipes endpoints"""
+import sys
 from flask import request, jsonify, make_response
 from flask_restplus import Resource
 
@@ -210,7 +211,6 @@ class SingleRecipeHandler(Resource):
 
         :param int category_id: The integer Id of the category\n
         :param int recipe_id: The integer Id of the recipe to be retrieved\n
-        :body json: The new recipe details
         :returns json response: An appropriate response depending on the request
         """
 
@@ -245,7 +245,7 @@ class SingleRecipeHandler(Resource):
 
             db.session.commit()
 
-            # Return the recipe
+            # Return the updated recipe
             resp_obj = {
                 "status": "Success!",
                 "recipes": [dict(
@@ -258,6 +258,59 @@ class SingleRecipeHandler(Resource):
                 )]
             }
             resp_obj = jsonify(resp_obj)
+            return make_response(resp_obj, 200)
+        # When an invalid category id is provided
+        resp_obj = dict(
+            status='Fail!',
+            message='Category does not exist!'
+        )
+        resp_obj = jsonify(resp_obj)
+        return make_response(resp_obj, 404)
+
+    @authorization_required
+    def delete(current_user, self, category_id, recipe_id):
+        """
+        This returns a specific recipe from the specified category
+
+        :param int category_id: The integer Id of the category\n
+        :param int recipe_id: The integer Id of the recipe to be retrieved\n
+        :returns json response: An appropriate response depending on the request
+        """
+
+        if not current_user:
+            resp_obj = dict(
+                status='Fail!',
+                message='Invalid token. Login to use this resource!'
+            )
+            resp_obj = jsonify(resp_obj)
+            return make_response(resp_obj, 401)
+
+        category = current_user.categories.filter_by(id=category_id).first()
+        if category:
+            selected_recipe = category.recipes.filter_by(id=recipe_id).first()
+
+            # When the recipe requested does not exist
+            if not selected_recipe:
+                resp_obj = dict(
+                    status="Fail!",
+                    message="Recipe does not exist!"
+                )
+                resp_obj = jsonify(resp_obj)
+                return make_response(resp_obj, 404)
+
+            name = selected_recipe.name
+
+            # Delete the selected recipe
+            db.session.delete(selected_recipe)
+            db.session.commit()
+
+            # Render response
+            resp_obj = {
+                "status": "Success!",
+                "message": "Recipe " + name + " was deleted successfully!"
+            }
+            resp_obj = jsonify(resp_obj)
+            print(resp_obj.data.decode(), file=sys.stdout)
             return make_response(resp_obj, 200)
         # When an invalid category id is provided
         resp_obj = dict(

--- a/app/restplus.py
+++ b/app/restplus.py
@@ -1,6 +1,9 @@
 """RESTPLus API init"""
 from flask_restplus import Api
 
+# Linting exception
+# pylint: disable=C0103
+
 # Setup authorization
 authorization = {
     'apiKey': {
@@ -10,7 +13,8 @@ authorization = {
     }
 }
 
-API = Api( version='1.0', title="Yummy REST",
+API = Api(
+    version='1.0', title="Yummy REST",
     description="REST API implementation of the Yummy Recipes using Flask and PostgreSQL",
     authorizations=authorization
 )

--- a/app/serializers.py
+++ b/app/serializers.py
@@ -3,6 +3,9 @@
 from flask_restplus import fields
 from .restplus import API
 
+# Linting exception
+# pylint: disable=C0103
+
 # User model serializer
 add_user = API.model('API user', {
     'email': fields.String(required=True, description='User email address'),

--- a/app/serializers.py
+++ b/app/serializers.py
@@ -25,3 +25,9 @@ category = API.model('Recipe Category', {
     'category_name': fields.String(required=True, description='Name of the recipe category'),
     'description': fields.String(required=True, description='A slight description of the category')
 })
+
+recipe = API.model('Recipe', {
+    'recipe_name': fields.String(required=True, description='Name of the recipe'),
+    'ingredients': fields.String(required=True, description='All the necessary ingredients'),
+    'description': fields.String(required=True, description='The instruction on preparation')
+})

--- a/instance/config.py
+++ b/instance/config.py
@@ -1,10 +1,17 @@
 """App intance configs"""
 
 import os
+# Linting exceptions
+
+# pylint: disable=C0103
+# pylint: disable=W0702
+# pylint: disable=W0703
+# pylint: disable=R0903
+# pylint: disable=E1101
+
 basedir = os.path.abspath(os.path.dirname(__file__))
 postgres_local_base = 'postgresql://localhost/'
 database_name = 'yummy_rest'
-
 
 class BaseConfig:
     """Base configuration."""

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -38,6 +38,13 @@ test_recipe = json.dumps(dict(
     description="Prepare with care and serve with love"
 ))
 
+# update recipe details
+test_recipe_update = json.dumps(dict(
+    recipe_name='Mint Chocolate chip',
+    ingredients="Some ingredients there\n\rSome others here.",
+    description="Prepare with love and serve with care"
+))
+
 # Register test user
 def register_user(self):
     """Registers a test user"""

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -28,6 +28,13 @@ test_category_update = json.dumps(dict(
     description="All my pie recipes."
 ))
 
+# recipe details
+test_recipe = json.dumps(dict(
+    recipe_name='Chocolate chip',
+    ingredients="Some ingredients here\n\rSome others there.",
+    description="Prepare with care and serve with love"
+))
+
 # Register test user
 def register_user(self):
         """Registers a test user"""

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -3,6 +3,9 @@ This are helper methods/functions shared across test cases
 """
 from flask import json
 
+# linting exception
+# pylint: disable=C0103
+
 # Registration details
 user_details = dict(
     email="isaac@yum.my",
@@ -37,14 +40,14 @@ test_recipe = json.dumps(dict(
 
 # Register test user
 def register_user(self):
-        """Registers a test user"""
-        return self.client.post('/auth/register',
-                                  data=json.dumps(user_details), content_type='application/json'
-                                )
+    """Registers a test user"""
+    return self.client.post('/auth/register',
+                            data=json.dumps(user_details), content_type='application/json'
+                           )
 
 # Login test user
 def login_user(self):
     """Logs a user in"""
     return self.client.post('/auth/login',
-                              data=json.dumps(login_details), content_type='application/json'
-                            )
+                            data=json.dumps(login_details), content_type='application/json'
+                           )

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -3,7 +3,6 @@ This Test suite houses the category endpoint tests
 """
 import sys
 import json
-# from werkzeug.datastructures import Headers
 from flask_testing import TestCase
 from app import APP
 from app.models import db, Category
@@ -23,8 +22,6 @@ class CategoryTestCase(BaseTestCase):
             self.assertEqual(register_resp.status_code, 201)
             login_resp = login_user(self)
             self.assertEqual(login_resp.status_code, 200)
-            # h = Headers()
-            # h.add("Authorization", login_resp_data['access_token'] )
             access_token = json.loads(login_resp.data.decode())['access_token']
             response = self.client.post('/category', headers=dict(
                 Authorization=access_token

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -1,12 +1,12 @@
 """
 This Test suite houses the category endpoint tests
 """
-import sys
 import json
-from flask_testing import TestCase
-from app import APP
-from app.models import db, Category
 from .test_auth import BaseTestCase
+
+# Linting exceptions
+# pylint: disable=C0103
+# pylint: disable=W0201
 
 # Test Helpers
 from .helpers import register_user, login_user, test_category, test_category_update
@@ -62,7 +62,9 @@ class CategoryTestCase(BaseTestCase):
 
         with self.client:
             # Ensure that resource can not be accessed without an access token
-            response = self.client.post('/category', data=test_category, content_type='application/json')
+            response = self.client.post(
+                '/category', data=test_category, content_type='application/json'
+            )
             response_data = json.loads(response.data.decode())
             self.assertEqual(response.status_code, 401)
             self.assertEqual(response_data['status'], "Fail!")
@@ -115,7 +117,6 @@ class CategoryTestCase(BaseTestCase):
             )
             self.assertEqual(response.status_code, 200)
             response_data = json.loads(response.data.decode())
-            print(response_data, file=sys.stdout)
             self.assertTrue(response_data['message'] == "Success!")
             self.assertTrue(len(response_data['categories']) == 0)
             # Create a test category
@@ -163,7 +164,7 @@ class CategoryTestCase(BaseTestCase):
             response_data = json.loads(response.data.decode())
             self.assertEqual(response_data['status'], "Fail!")
             self.assertEqual(response_data['message'], "Please provide an access token!")
-            
+
             # Attempt access with invalid token
             x_access_token = "5u32905ugnw9e8ut025u2"
             x_auth_header = dict(Authorization=x_access_token)
@@ -181,7 +182,6 @@ class CategoryTestCase(BaseTestCase):
             )
             self.assertEqual(response.status_code, 200)
             response_data = json.loads(response.data.decode())
-            print(response_data, file=sys.stdout)
             self.assertEqual(response_data['status'], "Success!")
             self.assertTrue(len(response_data['categories']) == 1)
             self.assertEqual(response_data['categories'][0]['category_name'], "Cookies")
@@ -192,7 +192,6 @@ class CategoryTestCase(BaseTestCase):
             )
             self.assertEqual(response.status_code, 404)
             response_data = json.loads(response.data.decode())
-            print(response_data, file=sys.stdout)
             self.assertEqual(response_data['status'], "Fail!")
             self.assertEqual(response_data['message'], "Sorry, category does not exist!")
 
@@ -228,7 +227,7 @@ class CategoryTestCase(BaseTestCase):
             response_data = json.loads(response.data.decode())
             self.assertEqual(response_data['status'], "Fail!")
             self.assertEqual(response_data['message'], "Please provide an access token!")
-            
+
             # Attempt access with invalid token
             x_access_token = "5u32905ugnw9e8ut025u2"
             x_auth_header = dict(Authorization=x_access_token)
@@ -248,7 +247,6 @@ class CategoryTestCase(BaseTestCase):
             )
             self.assertEqual(response.status_code, 200)
             response_data = json.loads(response.data.decode())
-            print(response_data, file=sys.stdout)
             self.assertEqual(response_data['status'], "Success!")
             self.assertTrue(len(response_data['categories']) == 1)
             self.assertEqual(response_data['categories'][0]['category_name'], "Pies")
@@ -260,7 +258,6 @@ class CategoryTestCase(BaseTestCase):
             )
             self.assertEqual(response.status_code, 404)
             response_data = json.loads(response.data.decode())
-            print(response_data, file=sys.stdout)
             self.assertEqual(response_data['status'], "Fail!")
             self.assertEqual(response_data['message'], "Sorry, category does not exist!")
 
@@ -295,7 +292,7 @@ class CategoryTestCase(BaseTestCase):
             response_data = json.loads(response.data.decode())
             self.assertEqual(response_data['status'], "Fail!")
             self.assertEqual(response_data['message'], "Please provide an access token!")
-            
+
             # Attempt access with invalid token
             x_access_token = "5u32905ugnw9e8ut025u2"
             x_auth_header = dict(Authorization=x_access_token)
@@ -313,7 +310,6 @@ class CategoryTestCase(BaseTestCase):
             )
             self.assertEqual(response.status_code, 200)
             response_data = json.loads(response.data.decode())
-            print(response_data, file=sys.stdout)
             self.assertEqual(response_data['status'], "Success!")
 
             # Attempt delete of non-existent category
@@ -322,6 +318,5 @@ class CategoryTestCase(BaseTestCase):
             )
             self.assertEqual(response.status_code, 404)
             response_data = json.loads(response.data.decode())
-            print(response_data, file=sys.stdout)
             self.assertEqual(response_data['status'], "Fail!")
             self.assertEqual(response_data['message'], "Sorry, category does not exist!")

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -6,6 +6,7 @@ import json
 from .helpers import register_user, login_user, test_category, test_recipe
 from .test_auth import BaseTestCase
 
+# Linting exceptions
 # pylint: disable=C0103
 # pylint: disable=W0201
 

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -1,0 +1,117 @@
+"""
+This is the unit test suite for the recipes endpoint
+"""
+import sys
+import json
+from flask_testing import TestCase
+
+from app.models import User, Category, Recipe
+from .helpers import register_user, login_user, test_category, test_recipe
+from .test_auth import BaseTestCase
+
+class RecipesTestCase(BaseTestCase):
+    """
+    This class contains the tests for the recipe CRUD endpoints
+    """
+
+    def set_up(self):
+        with self.client as test_client:
+            register_resp = register_user(self)
+            self.assertEqual(register_resp.status_code, 201)
+            login_resp = login_user(self)
+            self.assert200(login_resp, "User not logged in")
+            login_resp_data = json.loads(login_resp.data.decode())
+            self.auth_header = dict(
+                Authorization=login_resp_data['access_token']
+            )
+            category_create_resp = test_client.post(
+                '/category', headers=self.auth_header, data=test_category,
+                content_type='application/json'
+            )
+            self.assertEqual(category_create_resp.status_code, 201)
+
+    def test_recipe_resource_security(self):
+        """
+        Ensures that the resource is protected/private
+        """
+        with self.client as test_client:
+            # Test the resouce with No authorization
+            response = test_client.post(
+                '/category/1/recipes', data=test_recipe,
+                content_type='application/json'
+            )
+            print(response.data.decode(), file=sys.stdout)
+            self.assert401(response, "Wrong reponse code: " + str(response.status_code))
+            response_data = json.loads(response.data.decode())
+            self.assertEqual(response_data['status'], 'Fail!')
+            self.assertEqual(response_data['message'], "Please provide an access token!")
+            # test the resource with invalid authorization
+            response = test_client.post(
+                '/category/1/recipes', headers=dict(Authorization="Some98247982hnidutie3rojgnadf"),
+                data=test_recipe, content_type='application/json'
+            )            
+            self.assert401(response, "Wrong reponse code: " + str(response.status_code))
+            response_data = json.loads(response.data.decode())
+            self.assertEqual(response_data['status'], 'Fail!')
+            self.assertEqual(response_data['message'], 'Invalid token. Login to use this resource!')
+
+    def test_recipe_creation_invalid_category(self):
+        """
+        Ensures that if user attempts to add a recipe to a non existent category,
+        the action is flagged as an error
+        """
+
+        self.set_up()
+        with self.client as test_client:
+            # when a wrong or invalid category_id is provided
+            response = test_client.post(
+                'category/2/recipes', headers=self.auth_header,
+                data=test_recipe, content_type='application/json'
+            )
+            self.assert400(response, "Invalid status code: " + str(response.status_code))
+            response_data = json.loads(response.data.decode())
+            self.assertEqual(response_data['message'], 'Invalid category!')
+            self.assertEqual(response_data['status'], 'Fail!')
+
+    def test_recipe_creation(self):
+        """
+        Ensures a user can create a recipe in a specified category
+        """
+
+        self.set_up()
+        with self.client as test_client:
+            
+            response = test_client.post(
+                '/category/1/recipes', headers=self.auth_header,
+                data=test_recipe, content_type='application/json'
+            )
+            self.assertEqual(response.status_code, 201)
+            response_data = json.loads(response.data.decode())
+            self.assertEqual(response_data['status'], 'Success!')
+            self.assertEqual(len(response_data['recipes']), 1)
+
+    def test_recipe_duplication(self):
+        """
+        Ensures a user can create a recipe in a specified category
+        """
+
+        self.set_up()
+        with self.client as test_client:
+            # add recipe
+            response = test_client.post(
+                '/category/1/recipes', headers=self.auth_header,
+                data=test_recipe, content_type='application/json'
+            )
+            self.assertEqual(response.status_code, 201)
+            response_data = json.loads(response.data.decode())
+            self.assertEqual(response_data['status'], 'Success!')
+            self.assertEqual(len(response_data['recipes']), 1)
+            # Duplicate recipe
+            response = test_client.post(
+                '/category/1/recipes', headers=self.auth_header,
+                data=test_recipe, content_type='application/json'
+            )
+            self.assertEqual(response.status_code, 400)
+            response_data = json.loads(response.data.decode())
+            self.assertEqual(response_data['status'], 'Fail!')
+            self.assertEqual(response_data['message'], 'Recipe already exists!')

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -1,13 +1,13 @@
 """
 This is the unit test suite for the recipes endpoint
 """
-import sys
 import json
-from flask_testing import TestCase
 
-from app.models import User, Category, Recipe
 from .helpers import register_user, login_user, test_category, test_recipe
 from .test_auth import BaseTestCase
+
+# pylint: disable=C0103
+# pylint: disable=W0201
 
 class RecipesTestCase(BaseTestCase):
     """
@@ -15,6 +15,9 @@ class RecipesTestCase(BaseTestCase):
     """
 
     def set_up(self):
+        """
+        Custom test setup
+        """
         with self.client as test_client:
             register_resp = register_user(self)
             self.assertEqual(register_resp.status_code, 201)
@@ -48,7 +51,7 @@ class RecipesTestCase(BaseTestCase):
             response = test_client.post(
                 '/category/1/recipes', headers=dict(Authorization="Some98247982hnidutie3rojgnadf"),
                 data=test_recipe, content_type='application/json'
-            )            
+            )
             self.assert401(response, "Wrong reponse code: " + str(response.status_code))
             response_data = json.loads(response.data.decode())
             self.assertEqual(response_data['status'], 'Fail!')
@@ -72,14 +75,14 @@ class RecipesTestCase(BaseTestCase):
             self.assertEqual(response_data['message'], 'Invalid category!')
             self.assertEqual(response_data['status'], 'Fail!')
 
-    def test_recipe_creation(self):
+    def test_recipe_creation_valid_category(self):
         """
         Ensures a user can create a recipe in a specified category
         """
 
         self.set_up()
         with self.client as test_client:
-            
+
             response = test_client.post(
                 '/category/1/recipes', headers=self.auth_header,
                 data=test_recipe, content_type='application/json'
@@ -133,7 +136,7 @@ class RecipesTestCase(BaseTestCase):
             response = test_client.get(
                 '/category/1/recipes', headers=dict(Authorization="Some98247982hnidutie3rojgnadf"),
                 content_type='application/json'
-            )            
+            )
             self.assert401(response, "Wrong reponse code: " + str(response.status_code))
             response_data = json.loads(response.data.decode())
             self.assertEqual(response_data['status'], 'Fail!')
@@ -181,3 +184,80 @@ class RecipesTestCase(BaseTestCase):
             response_data = json.loads(response.data.decode())
             self.assertEqual(response_data['status'], 'Fail!')
             self.assertEqual(response_data['message'], 'Invalid category!')
+
+    def test_single_recipe_retival_resource_security(self):
+        """
+        Ensure that this resource is protected from unauthorized use
+        """
+
+        # Attempt access with no authorization
+        with self.client as test_client:
+            response = test_client.get(
+                '/category/1/recipes/1', content_type='application/json'
+            )
+            self.assert401(response, "Invalid status code: " + str(response.status_code))
+            response_data = json.loads(response.data.decode())
+            self.assertEqual(response_data['status'], 'Fail!')
+            self.assertEqual(response_data['message'], 'Please provide an access token!')
+        # Attempt access with invalid authorization
+        with self.client as test_client:
+            response = test_client.get(
+                '/category/1/recipes/1', headers=dict(Authorization="gih248h9ehg2iu028"),
+                content_type='application/json'
+            )
+            self.assert401(response, "Invalid status code: " + str(response.status_code))
+            response_data = json.loads(response.data.decode())
+            self.assertEqual(response_data['status'], 'Fail!')
+            self.assertEqual(
+                response_data['message'],
+                'Invalid token. Login to use this resource!'
+            )
+
+    def test_single_recipe_retrival(self):
+        """
+        Ensure that requests to view single recipes are handled accordingly
+        """
+
+        # setup
+        self.set_up()
+
+        with self.client as test_client:
+            # add test recipe
+            response = test_client.post(
+                '/category/1/recipes', headers=self.auth_header,
+                data=test_recipe, content_type='application/json'
+            )
+            self.assertEqual(response.status_code, 201)
+
+            # Retrieve recipe from a valid category with a
+            # valid recipe id
+            response = test_client.get(
+                '/category/1/recipes/1', headers=self.auth_header,
+                content_type='application/json'
+            )
+            self.assert200(response, "Invalid status code: " + str(response.status_code))
+            response_data = json.loads(response.data.decode())
+            self.assertEqual(response_data['status'], "Success!")
+            self.assertEqual(len(response_data['recipes']), 1)
+
+            # retrieve recipe from a valid category with an
+            # invalid recipe id
+            response = test_client.get(
+                '/category/1/recipes/2', headers=self.auth_header,
+                content_type='application/json'
+            )
+            self.assert404(response, "Invalid status code: " + str(response.status_code))
+            response_data = json.loads(response.data.decode())
+            self.assertEqual(response_data['status'], "Fail!")
+            self.assertEqual(response_data['message'], "Recipe does not exist!")
+
+            # retrieve recipe from an valid category with a
+            # valid/invalid recipe id
+            response = test_client.get(
+                '/category/2/recipes/2', headers=self.auth_header,
+                content_type='application/json'
+            )
+            self.assert404(response, "Invalid status code: " + str(response.status_code))
+            response_data = json.loads(response.data.decode())
+            self.assertEqual(response_data['status'], "Fail!")
+            self.assertEqual(response_data['message'], "Category does not exist!")


### PR DESCRIPTION
## What this PR is for

The API's recipes endpoints are protected endpoints that are defined under the `/category/<int:category_id>/recipes` namespace
There are five endpoints which handle new recipe creation, view for all users recipes in a particular category, single recipe view, update and delete.

The PR also fixes another some lint issues


## Feature Stories (Pivotal Tracker)
recipe creation [#153856583](https://www.pivotaltracker.com/story/show/153856583)
recipes view [#153855713](https://www.pivotaltracker.com/story/show/153855713)
single recipe view [#153858079](https://www.pivotaltracker.com/story/show/153858079)
single recipe update [#153858172](https://www.pivotaltracker.com/story/show/153858172)
single recipe delete [#153858236](https://www.pivotaltracker.com/story/show/153858236) 

### What to review

1. Ensure the tasks listed on the story are  well and fully completed.
2. Ensure that the acceptance criteria is met.
3. Confirm the `Dev Notes` (for each individual story) were adhered to.

### How to review

#### Installation

> Prerequisites: PostgreSQL>=9.6, Python>=3.6

```bash
$ createdb -U postgres yummy_rest # Set up the database first:
$ createdb -U postgres yummy_rest_test
$ git clone -b dev-recipe https://github.com/indungu/yummy-rest # clone repo on required branch
$ cd yummy-recipes
$ virtualenv venv
$ source venv/bin/activate
(venv)...$ pip install -r requirements.txt
(venv)...$ python manage.py db init # create the relations
(venv)...$ python manage.py db migrate 
(venv)...$ python manage.py db upgrade 
(venv)...$ pytest # Ensure all test are passing
(venv)...$ python run.py
 ```

## Noted issues

> All the features seem to be working to required. The only problem is when user provides an letter, string or special character the `category_id` or the `recipe_id`, the server is hit with malformed URL path and throws the builtin prompt which is in `html` instead of `json`. 
